### PR TITLE
Allow to set the payload in a different key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ $data = $jwtWrapper->extractData();
 $data = $jwtWrapper->extractData($token);
 ```
 
+### Issuer validation
+
+By default the issuer is validated against the server name. If you want to disable this validation you can call the method below:
+
+```php
+$data = $jwtWrapper->extractData($token, false); // Setting false disables the issuer validation
+```
+
 ### Adding a Leeway
 
 You can add a leeway to account for when there is a clock skew times between

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
       "ByJG\\Util\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Test\\": "tests/"
+    }
+  },
   "license": "MIT",
   "require": {
     "firebase/php-jwt": "^6",

--- a/tests/JwtWrapperHashTest.php
+++ b/tests/JwtWrapperHashTest.php
@@ -111,7 +111,12 @@ class JwtWrapperHashTest extends TestCase
 
     public function testSuccessfulFlowSubject()
     {
-        $jwt = $this->object->createJwtData(array_merge($this->dataToToken, ["iss" => "new_issuer", "sub" => "userid"]), payloadKey: null);
+        $jwt = $this->object->createJwtData(
+            array_merge($this->dataToToken, ["iss" => "new_issuer", "sub" => "userid"]),
+            60,
+            0,
+            null
+        );
 
         $this->assertEquals([
             'iat'  => $jwt["iat"],  // Not deterministic for the test

--- a/tests/JwtWrapperSecretTest.php
+++ b/tests/JwtWrapperSecretTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Test;
+
 use ByJG\Util\JwtWrapper;
 
 require_once __DIR__ . '/JwtWrapperHashTest.php';


### PR DESCRIPTION
Added to `createJwtData` the parameter `payloadKey`. It will define where the payload will be set. By default it is `data`
